### PR TITLE
Fix: Bash script xargs command is unnecessary (fixes #772)

### DIFF
--- a/scripts/generate-cards.sh
+++ b/scripts/generate-cards.sh
@@ -19,5 +19,5 @@ find "$CARDS_DIR" -type f -name "*.html" | sed "s|^$CARDS_DIR/|  \"|; s|$|\",|" 
 # Close the JavaScript array
 echo "];" >> "$OUTPUT_FILE"
 
-echo "$OUTPUT_FILE generated successfully with $(ls -1 $CARDS_DIR/*.html | wc -l | xargs) files."
+echo "$OUTPUT_FILE generated successfully with $(ls -1 $CARDS_DIR/*.html | wc -l) files."
 


### PR DESCRIPTION
Please merge if you consider this useful. Thank you.

I tested the fix, same result:
```
$ ./scripts/generate-cards.sh 
scripts/contributors.js generated successfully with 146 files.
```