### PR TITLE
fix corrupted flags images by changing its source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,25 @@ Head over to [contribution guide](https://github.com/Roshanjossey/code-contribut
 
 #### _Read this in [other languages](docs/translations/Translations.md)._
 
-<kbd>[<img title="Deutsch" alt="Deutsch" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/de.svg" width="22">](docs/translations/de/README.de.md)</kbd>
-<kbd>[<img title="Português (Brasil)" alt="Português (Brasil)" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/br.svg" width="22">](docs/translations/pt_br/README.pt_br.md)</kbd>
-<kbd>[<img title="日本語" alt="日本語" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/jp.svg" width="22">](docs/translations/ja/README.ja.md)</kbd>
-<kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/id.svg" width="22">](docs/translations/id/README.id.md)</kbd>
-<kbd>[<img title="中文" alt="中文" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/cn.svg" width="22">](docs/translations/cn/README.cn.md)</kbd>
-<kbd>[<img title="Spain" alt="Spain" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/es.svg" width="22">](docs/translations/es/README.es.md)</kbd>
-<kbd>[<img title="Türkiye" alt="Türkiye" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/tr.svg" width="22">](docs/translations/tr/README.tr.md)</kbd>
-<kbd>[<img title="Farsi" alt="Farsi" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ir.svg" width="22">](docs/translations/fa/README.fa.md)</kbd>
-<kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/it.svg" width="22">](docs/translations/it/README.it.md)</kbd>
-<kbd>[<img title="العربية" alt="العربية" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/sa.svg" width="22">](docs/translations/ar/README.ar.md)</kbd>
-<kbd>[<img title="한국어" alt="한국어" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/kr.svg" width="22">](docs/translations/kr/README.kr.md)</kbd>
-<kbd>[<img title="Vietnam" alt="Vietnam" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/vn.svg" width="22">](docs/translations/vn/README.es.md)</kbd>
-<kbd>[<img title="Polish" alt="Polish" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pl.svg" width="22">](docs/translations/pl/README.pl.md)</kbd>
-<kbd>[<img title="Russian" alt="Russian" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ru.svg" width="22">](docs/translations/ru/README.ru.md)</kbd>
+<kbd>[<img title="Deutsch" alt="Deutsch" src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Germany.svg" width="22">](docs/translations/de/README.de.md)</kbd>
+<kbd>[<img title="Português (Brasil)" alt="Português (Brasil)" src="https://upload.wikimedia.org/wikipedia/commons/0/05/Flag_of_Brazil.svg" width="22">](docs/translations/pt_br/README.pt_br.md)</kbd>
+<kbd>[<img title="日本語" alt="日本語" src="https://upload.wikimedia.org/wikipedia/commons/9/9e/Flag_of_Japan.svg" width="22">](docs/translations/ja/README.ja.md)</kbd>
+<kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://upload.wikimedia.org/wikipedia/commons/9/9f/Flag_of_Indonesia.svg" width="22">](docs/translations/id/README.id.md)</kbd>
+<kbd>[<img title="中文" alt="中文" src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People%27s_Republic_of_China.svg" width="22">](docs/translations/cn/README.cn.md)</kbd>
+<kbd>[<img title="Español de España" alt="Español de España" src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Flag_of_Spain.svg" width="22">](docs/translations/es/README.es.md)</kbd>
+<kbd>[<img title="Türkiye" alt="Türkiye" src="https://upload.wikimedia.org/wikipedia/commons/b/b4/Flag_of_Turkey.svg" width="22">](docs/translations/tr/README.tr.md)</kbd>
+<kbd>[<img title="فارسی" alt="فارسی" src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Iran_before_1979_Revolution.svg" width="22">](docs/translations/fa/README.fa.md)</kbd>
+<kbd>[<img title="Italiano" alt="Italiano" src="https://upload.wikimedia.org/wikipedia/commons/0/03/Flag_of_Italy.svg" width="22">](docs/translations/it/README.it.md)</kbd>
+<kbd>[<img title="العربية" alt="العربية" src="https://upload.wikimedia.org/wikipedia/commons/0/0d/Flag_of_Saudi_Arabia.svg" width="22">](docs/translations/ar/README.ar.md)</kbd>
+<kbd>[<img title="한국어" alt="한국어" src="https://upload.wikimedia.org/wikipedia/commons/0/09/Flag_of_South_Korea.svg" width="22">](docs/translations/kr/README.kr.md)</kbd>
+<kbd>[<img title="Vietnam" alt="Vietnam" src="https://upload.wikimedia.org/wikipedia/commons/2/21/Flag_of_Vietnam.svg" width="22">](docs/translations/vn/README.vn.md)</kbd>
+<kbd>[<img title="Polish" alt="Polish" src="https://upload.wikimedia.org/wikipedia/commons/1/12/Flag_of_Poland.svg" width="22">](docs/translations/pl/README.pl.md)</kbd>
+<kbd>[<img title="Russian" alt="Russian" src="https://upload.wikimedia.org/wikipedia/commons/f/f3/Flag_of_Russia.svg" width="22">](docs/translations/ru/README.ru.md)</kbd>
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I have added a screenshot from browser with my changes
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.
<img width="422" height="181" alt="image" src="https://github.com/user-attachments/assets/2c3fc9eb-590b-472f-8a85-e8ce5554a535" />
I'd like correct these flags.