### PR TITLE
fix: add standard background-clip property alongside webkit prefix

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,7 @@ h1 span {
     -webkit-text-fill-color: #0000;
     background: linear-gradient(90deg, #60faa3, #1dd829);
     -webkit-background-clip: text;
+    background-clip: text;
 }
 
 .success.button {


### PR DESCRIPTION
The h1 span gradient text effect previously declared only -webkit-background-clip: text, which triggers a CSS lint warning because background-clip is now part of the CSS standard and most modern browsers support the unprefixed version.

Adding background-clip: text alongside the webkit-prefixed version ensures forward compatibility and resolves the warning, while preserving support for older WebKit-based browsers.

Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [ ] I have added a screenshot from browser with my changes
- [ ] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.
