### PR TITLE
Fix Vietnam README translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Head over to [contribution guide](https://github.com/Roshanjossey/code-contribut
 <kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/it.svg" width="22">](docs/translations/it/README.it.md)</kbd>
 <kbd>[<img title="العربية" alt="العربية" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/sa.svg" width="22">](docs/translations/ar/README.ar.md)</kbd>
 <kbd>[<img title="한국어" alt="한국어" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/kr.svg" width="22">](docs/translations/kr/README.kr.md)</kbd>
-<kbd>[<img title="Vietnam" alt="Vietnam" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/vn.svg" width="22">](docs/translations/vn/README.es.md)</kbd>
+<kbd>[<img title="Vietnam" alt="Vietnam" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/vn.svg" width="22">](docs/translations/vn/README.vn.md)</kbd>
 <kbd>[<img title="Polish" alt="Polish" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pl.svg" width="22">](docs/translations/pl/README.pl.md)</kbd>
 <kbd>[<img title="Russian" alt="Russian" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ru.svg" width="22">](docs/translations/ru/README.ru.md)</kbd>


### PR DESCRIPTION
Point the Vietnam flag to `README.vn.md` instead of the incorrect Spanish `README.es.md` path.

**Before:** `docs/translations/vn/README.es.md`
**After:** `docs/translations/vn/README.vn.md`

Verified on branch `fix/vietnam-readme-link`: Vietnam flag opens the Vietnamese README.

![Vietnam README opens correctly](https://raw.githubusercontent.com/habiibullahm/code-contributions/pr-assets-1305/assets/vietnam-readme-verified.png)

Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I have added a screenshot from browser with my changes
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.

### Things I'd like to improve
1. Several language flag images in the root README fail to load (Spain / Arabic / Farsi CDN flag assets), so the translation row looks broken even when the links are correct.
2. The CONTRIBUTING guide could briefly note that `scripts/contributors.js` should not be edited in card PRs (maintainers revert it), to avoid confusion for first-time contributors.
3. A short “common Windows pitfalls” note (invalid filename characters in contributor cards) would help Windows users who hit clone/checkout errors.
