### PR TITLE
Complete translations index and fix Portuguese README link

### DIFF
--- a/docs/translations/Translations.md
+++ b/docs/translations/Translations.md
@@ -10,5 +10,9 @@
 | <img alt="Türkiye" title="Türkiye" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/tr.svg" width="22"> | [Türkiye](tr/README.tr.md)  |
 | <img alt="Italiano" title="Italiano" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/it.svg" width="22"> | [Italiano](it/README.it.md)  |
 | <img alt="Spain" title="Spain" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/es.svg" width="22"> | [Spain](es/README.es.md)                    |
+| <img alt="Farsi" title="Farsi" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ir.svg" width="22"> | [Farsi](fa/README.fa.md)                    |
 | <img alt="العربية" title="العربية" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/sa.svg" width="22"> | [العربية](ar/README.ar.md)                  |
 | <img title="한국어" alt="한국어" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/kr.svg" width="22"> | [한국어](kr/README.kr.md)  |
+| <img title="Vietnam" alt="Vietnam" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/vn.svg" width="22"> | [Vietnam](vn/README.vn.md)  |
+| <img title="Polish" alt="Polish" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pl.svg" width="22"> | [Polish](pl/README.pl.md)  |
+| <img title="Russian" alt="Russian" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ru.svg" width="22"> | [Russian](ru/README.ru.md)  |

--- a/docs/translations/pt_br/README.pt_br.md
+++ b/docs/translations/pt_br/README.pt_br.md
@@ -1,6 +1,6 @@
 Este é um projeto que permite que você pratique a contribuição de código para projetos de código aberto.
 
-Presumimos que você já tenha concluído o tutorial em [first contributions](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.id.md).
+Presumimos que você já tenha concluído o tutorial em [first contributions](https://github.com/firstcontributions/first-contributions/blob/main/docs/translations/README.pt_br.md).
 
 Vá para [How to contribute](CONTRIBUTING.pt_br.md) para começar.
 


### PR DESCRIPTION
## Summary
- Add missing translation entries to `docs/translations/Translations.md` for languages that already exist: Farsi, Vietnamese, Polish, and Russian.
- Fix Brazilian Portuguese README link: it pointed to the Indonesian `README.id.md` instead of `README.pt_br.md`.

## Test plan
- [ ] Open `docs/translations/Translations.md` and confirm Farsi / Vietnam / Polish / Russian rows link to the correct README files
- [ ] Open `docs/translations/pt_br/README.pt_br.md` and confirm the first-contributions link goes to the Portuguese (Brasil) translation

Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I have added a screenshot from browser with my changes
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.

### Things I'd like to improve
1. Keep `Translations.md` in sync with the language flags listed in the root README whenever a new translation is added.
2. A quick CI check that translation index links resolve to existing files would catch mistakes like the Portuguese → Indonesian link.
