### PR TITLE
Clarify how to update the contributors list locally

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,16 +90,14 @@ You can add your card as an HTML file in contributors directory. Create a file w
 ```
 ## Add your card to contributors list
 
-Add the name of the file you created to `scripts/contributors.js` file.
+To preview your card locally, regenerate the contributors list:
 
-`scripts/contributors.js`
-```js
-const contributorFiles = [
-  "<your-github-id>.html", // add your file name here
-  "roshanjossey.html",
-  "gokultp.html",
-];
+```bash
+bash scripts/generate-cards.sh
 ```
+
+> [!IMPORTANT]
+> Do **not** commit changes to `scripts/contributors.js`. That file is generated automatically, and edits to it in pull requests are reverted.
 
 ## View your changes in a web browser
 


### PR DESCRIPTION
## Summary
- Update `docs/CONTRIBUTING.md` so the tutorial matches the real workflow.
- Tell contributors to run `bash scripts/generate-cards.sh` for local preview.
- Warn not to commit `scripts/contributors.js` (changes are auto-reverted by CI).

## Why
The guide previously told people to edit `scripts/contributors.js` manually, but:
1. PR preview already regenerates that file with `generate-cards.sh`
2. `.github/workflows/revert-contributors-change.yml` reverts committed edits to it

This caused confusion for first-time contributors.

## Test plan
- [ ] Read the updated section in `docs/CONTRIBUTING.md`
- [ ] Confirm it no longer instructs committing manual `contributors.js` edits
- [ ] Confirm it documents `bash scripts/generate-cards.sh`

Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x] I have added a screenshot from browser with my changes
- [x] There are no errors in the console
- [x] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [x] There are some things I'd like to improve in this tutorial. I have written them below.

### Things I'd like to improve
1. Apply the same `generate-cards.sh` guidance to the translated CONTRIBUTING files so they stay consistent with English.
2. Mention in the root README that only the HTML card file should be committed.
