### PR TITLE
Fix pull_request_target checkout error

### DIFF
--- a/.github/workflows/revert-contributors-change.yml
+++ b/.github/workflows/revert-contributors-change.yml
@@ -16,6 +16,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Revert changes to contributors.js
         run: |


### PR DESCRIPTION
### Description
Hello! When I submitted my contributor card, the automated CI failed with a `pull_request_target` checkout error. 

I investigated the issue and found that the `revert-contributors-change.yml` workflow was failing due to GitHub's updated security policies on checking out forks. I added the `allow-unsafe-pr-checkout: true` flag to the `actions/checkout` step as recommended by GitHub to resolve the issue. Hope this helps!
