### PR TITLE
Update Spain and Arabic flag image sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Head over to [contribution guide](https://github.com/Roshanjossey/code-contribut
 <kbd>[<img title="日本語" alt="日本語" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/jp.svg" width="22">](docs/translations/ja/README.ja.md)</kbd>
 <kbd>[<img title="Bahasa Indonesia" alt="Bahasa Indonesia" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/id.svg" width="22">](docs/translations/id/README.id.md)</kbd>
 <kbd>[<img title="中文" alt="中文" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/cn.svg" width="22">](docs/translations/cn/README.cn.md)</kbd>
-<kbd>[<img title="Spain" alt="Spain" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/es.svg" width="22">](docs/translations/es/README.es.md)</kbd>
+<kbd>[<img title="Spain" alt="Spain" src="https://raw.githubusercontent.com/hjnilsson/country-flags/master/svg/es.svg" width="22">](docs/translations/es/README.es.md)</kbd>
 <kbd>[<img title="Türkiye" alt="Türkiye" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/tr.svg" width="22">](docs/translations/tr/README.tr.md)</kbd>
 <kbd>[<img title="Farsi" alt="Farsi" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/ir.svg" width="22">](docs/translations/fa/README.fa.md)</kbd>
 <kbd>[<img title="Italiano" alt="Italiano" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/it.svg" width="22">](docs/translations/it/README.it.md)</kbd>
-<kbd>[<img title="العربية" alt="العربية" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/sa.svg" width="22">](docs/translations/ar/README.ar.md)</kbd>
+<kbd>[<img title="العربية" alt="العربية" src="https://raw.githubusercontent.com/hjnilsson/country-flags/master/svg/sa.svg" width="22">](docs/translations/ar/README.ar.md)</kbd>
 <kbd>[<img title="한국어" alt="한국어" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/kr.svg" width="22">](docs/translations/kr/README.kr.md)</kbd>
 <kbd>[<img title="Vietnam" alt="Vietnam" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/vn.svg" width="22">](docs/translations/vn/README.es.md)</kbd>
 <kbd>[<img title="Polish" alt="Polish" src="https://cdn.statically.io/gh/hjnilsson/country-flags/master/svg/pl.svg" width="22">](docs/translations/pl/README.pl.md)</kbd>


### PR DESCRIPTION
Before submitting this pull request, please go through the checklist below.
If you're doing something in the checklist, put an `x` inside `[ ]` so that `- [ ]` becomes `- [x]`

- [x ] I have added a screenshot from browser with my changes
- [x ] There are no errors in the console
- [x ] I had fun going through this tutorial (ノ^o^)ノ and learned on the way ٩(＾◡＾)۶
- [ ] There are some things I'd like to improve in this tutorial. I have written them below.

### 📝 Description of Changes
Hi there! 👋 I noticed that the flags for the Spain and Arabic translations were rendering as broken images in the `README.md`. 

**Why this happened:** 
Even though the original links were valid, GitHub's image caching proxy (Camo) sometimes fails to load images properly from external CDNs like `statically.io` and caches the error.

**How I fixed it:** 
I updated the image `src` URLs for those two specific flags to point directly to the native `raw.githubusercontent.com` link. This forces GitHub to render them correctly and prevents future caching issues.

### 📸 Screenshots

**Before:**
<img width="702" height="311" alt="image" src="https://github.com/user-attachments/assets/44ab82ca-d4a4-44df-a576-62ee4288775e" />

**After:**
<img width="710" height="314" alt="image" src="https://github.com/user-attachments/assets/b9cceacc-d506-4630-81c3-f12314d2d523" />

Thank you for this awesome project! Let me know if everything looks good. ✨
